### PR TITLE
build: Read the keystore properties from file if provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 .externalNativeBuild
 .cxx
 local.properties
+
+# Signing properties
+secure.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,9 @@ android {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.release
+            if (rootProject.file("secure.properties").exists()) {
+                signingConfig signingConfigs.release
+            }
         }
         debug {
             applicationIdSuffix '.debug'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,11 +13,32 @@ android {
         versionName "1.2.0"
     }
 
+    signingConfigs {
+        debug {
+                // Nothing here
+            }
+
+        release {
+            if (rootProject.file("secure.properties").exists()) {
+                Properties props = new Properties()
+                props.load(new FileInputStream(rootProject.file("secure.properties")))
+
+                storeFile file(props['key.store'])
+                keyAlias props['key.alias']
+                storePassword props['key.storepassword']
+                keyPassword props['key.keypassword']
+            } else {
+                // Nothing here
+            }
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.release
         }
         debug {
             applicationIdSuffix '.debug'


### PR DESCRIPTION
If the properties are declared in the secure.properties, read and apply them to build

Also ignore the file in the repository